### PR TITLE
Bug fix for clusterresourceset apply

### DIFF
--- a/exp/addons/internal/controllers/clusterresourceset_scope.go
+++ b/exp/addons/internal/controllers/clusterresourceset_scope.go
@@ -142,6 +142,8 @@ func (r *reconcileStrategyScope) apply(ctx context.Context, c client.Client, obj
 	}
 
 	patch := client.MergeFrom(currentObj.DeepCopy())
+	// metadata.ResourceVersion needs to be set to avoid webhook errors in applying
+	obj.SetResourceVersion(currentObj.GetResourceVersion())
 	if err = c.Patch(ctx, obj, patch); err != nil {
 		return errors.Wrapf(
 			err,


### PR DESCRIPTION
Retrieve resource version to avoid the following error:
```
'patching object storage.k8s.io/v1, Kind=CSIDriver /test2-csi.vsphere.vmware.com:
csidrivers.storage.k8s.io "csi.vsphere.vmware.com" is invalid: metadata.resourceVersion:
        Invalid value: 0x0: must be specified for an update'
```
