### PR TITLE
Make bottlerocket admin, control, custom bootstrap container images u…

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -46,8 +46,10 @@ func (in *KubeadmControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=kubeadmcontrolplanes,versions=v1beta1,name=default.kubeadmcontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=kubeadmcontrolplanes,versions=v1beta1,name=validation.kubeadmcontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Defaulter = &KubeadmControlPlane{}
-var _ webhook.Validator = &KubeadmControlPlane{}
+var (
+	_ webhook.Defaulter = &KubeadmControlPlane{}
+	_ webhook.Validator = &KubeadmControlPlane{}
+)
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (in *KubeadmControlPlane) Default() {
@@ -136,6 +138,9 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 	allowedPaths := [][]string{
 		{"metadata", "*"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "bottlerocketBootstrap", "*"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "bottlerocketAdmin", "*"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "bottlerocketControl", "*"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "bottlerocketCustomBootstrapContainers"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "imageRepository"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "imageTag"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "extraArgs", "*"},
@@ -150,6 +155,9 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, initConfiguration, nodeRegistration, "*"},
 		{spec, kubeadmConfigSpec, initConfiguration, patches, directory},
 		{spec, kubeadmConfigSpec, joinConfiguration, "bottlerocketBootstrap", "*"},
+		{spec, kubeadmConfigSpec, joinConfiguration, "bottlerocketAdmin", "*"},
+		{spec, kubeadmConfigSpec, joinConfiguration, "bottlerocketControl", "*"},
+		{spec, kubeadmConfigSpec, joinConfiguration, "bottlerocketCustomBootstrapContainers"},
 		{spec, kubeadmConfigSpec, joinConfiguration, "pause", "*"},
 		{spec, kubeadmConfigSpec, joinConfiguration, nodeRegistration, "*"},
 		{spec, kubeadmConfigSpec, joinConfiguration, patches, directory},

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -627,11 +627,29 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	validUpdateClusterConfBRBootstrapImage := before.DeepCopy()
 	validUpdateClusterConfBRBootstrapImage.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketBootstrap = bootstrapv1.BottlerocketBootstrap{ImageMeta: bootstrapv1.ImageMeta{ImageTag: "v1.1.0+new"}}
 
+	validUpdateClusterConfBRAdminImage := before.DeepCopy()
+	validUpdateClusterConfBRAdminImage.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketAdmin = bootstrapv1.BottlerocketAdmin{ImageMeta: bootstrapv1.ImageMeta{ImageTag: "v1.1.0+new"}}
+
+	validUpdateClusterConfBRControlImage := before.DeepCopy()
+	validUpdateClusterConfBRControlImage.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketControl = bootstrapv1.BottlerocketControl{ImageMeta: bootstrapv1.ImageMeta{ImageTag: "v1.1.0+new"}}
+
+	validUpdateClusterConfBRCustomBootstrapContainers := before.DeepCopy()
+	validUpdateClusterConfBRCustomBootstrapContainers.Spec.KubeadmConfigSpec.ClusterConfiguration.BottlerocketCustomBootstrapContainers = []bootstrapv1.BottlerocketBootstrapContainer{{ImageMeta: bootstrapv1.ImageMeta{ImageTag: "v1.1.0+new"}}}
+
 	validUpdateJoinConfPauseImage := before.DeepCopy()
 	validUpdateJoinConfPauseImage.Spec.KubeadmConfigSpec.JoinConfiguration.Pause = bootstrapv1.Pause{ImageMeta: bootstrapv1.ImageMeta{ImageTag: "v1.1.0+new"}}
 
 	validUpdateJoinConfBRBootstrapImage := before.DeepCopy()
 	validUpdateJoinConfBRBootstrapImage.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketBootstrap = bootstrapv1.BottlerocketBootstrap{ImageMeta: bootstrapv1.ImageMeta{ImageTag: "v1.1.0+new"}}
+
+	validUpdateJoinConfBRAdminImage := before.DeepCopy()
+	validUpdateJoinConfBRAdminImage.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketAdmin = bootstrapv1.BottlerocketAdmin{ImageMeta: bootstrapv1.ImageMeta{ImageTag: "v1.1.0+new"}}
+
+	validUpdateJoinConfBRControlImage := before.DeepCopy()
+	validUpdateJoinConfBRControlImage.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketControl = bootstrapv1.BottlerocketControl{ImageMeta: bootstrapv1.ImageMeta{ImageTag: "v1.1.0+new"}}
+
+	validUpdateJoinConfBRCustomBootstrapContainers := before.DeepCopy()
+	validUpdateJoinConfBRCustomBootstrapContainers.Spec.KubeadmConfigSpec.JoinConfiguration.BottlerocketCustomBootstrapContainers = []bootstrapv1.BottlerocketBootstrapContainer{{ImageMeta: bootstrapv1.ImageMeta{ImageTag: "v1.1.0+new"}}}
 
 	tests := []struct {
 		name                  string
@@ -984,6 +1002,24 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			kcp:       validUpdateClusterConfBRBootstrapImage,
 		},
 		{
+			name:      "should allow changes to cluster configuration bottlerocket admin image",
+			expectErr: false,
+			before:    before,
+			kcp:       validUpdateClusterConfBRAdminImage,
+		},
+		{
+			name:      "should allow changes to cluster configuration bottlerocket control image",
+			expectErr: false,
+			before:    before,
+			kcp:       validUpdateClusterConfBRControlImage,
+		},
+		{
+			name:      "should allow changes to cluster configuration bottlerocket custom bootstrap containers",
+			expectErr: false,
+			before:    before,
+			kcp:       validUpdateClusterConfBRCustomBootstrapContainers,
+		},
+		{
 			name:      "should allow changes to join configuration pause image",
 			expectErr: false,
 			before:    before,
@@ -994,6 +1030,24 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: false,
 			before:    before,
 			kcp:       validUpdateJoinConfBRBootstrapImage,
+		},
+		{
+			name:      "should allow changes to join configuration bottlerocket admin image",
+			expectErr: false,
+			before:    before,
+			kcp:       validUpdateJoinConfBRAdminImage,
+		},
+		{
+			name:      "should allow changes to join configuration bottlerocket control image",
+			expectErr: false,
+			before:    before,
+			kcp:       validUpdateJoinConfBRControlImage,
+		},
+		{
+			name:      "should allow changes to join configuration bottlerocket custom bootstrap containers",
+			expectErr: false,
+			before:    before,
+			kcp:       validUpdateJoinConfBRCustomBootstrapContainers,
 		},
 	}
 


### PR DESCRIPTION
…pdatable in webhook

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Update KCP fails because updating `bottlerocketCustomBootstrapContainers` is forbidden. We should allow it for all BR images.

```
2023-01-05T17:42:02.843Z	V5	Error happened during retry	{"error": "executing apply: The KubeadmControlPlane \"test-snow\" is invalid: \n* spec.kubeadmConfigSpec.joinConfiguration.bottlerocketCustomBootstrapContainers: Forbidden: cannot be modified\n* spec.kubeadmConfigSpec.clusterConfiguration.bottlerocketCustomBootstrapContainers: Forbidden: cannot be modified\n", "retries": 7}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
