### PR TITLE
Mark etcd machine status to running after etcd controller adds the etcd machine ready label

### DIFF
--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -30,8 +30,11 @@ const (
 	// MachineControlPlaneLabelName is the label set on machines or related objects that are part of a control plane.
 	MachineControlPlaneLabelName = "cluster.x-k8s.io/control-plane"
 
-	//MachineEtcdClusterLabelName is the label set on machines or related objects that are part of an etcd cluster
+	// MachineEtcdClusterLabelName is the label set on machines or related objects that are part of an etcd cluster
 	MachineEtcdClusterLabelName = "cluster.x-k8s.io/etcd-cluster"
+
+	// MachineEtcdReadyLabelName is the label set on machines that have succesfully joined the etcd cluster.
+	MachineEtcdReadyLabelName = "cluster.x-k8s.io/etcd-ready"
 
 	// ExcludeNodeDrainingAnnotation annotation explicitly skips node draining if set.
 	ExcludeNodeDrainingAnnotation = "machine.cluster.x-k8s.io/exclude-node-draining"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Unlike control plane and worker machines, where we check both the nodeRef and infrastructure before marking machine.status to `running`, etcd machines are marked as `running` whenever the infrastructure is ready. We can't check nodeRef for etcd machine becasue they are not K8s nodes and nodeRef is not set. This is problematic because sometimes the underlying infrastructure can be ready without the etcd cluster in ready state. We need to run proper health check on etcd cluster level before marking the etcd machine as running.

https://github.com/aws/etcdadm-controller/pull/15 handles the logic of checking etcd cluster and adding etcd ready label to machine through the etcd cluster reconciler. We need to merge this PR before the etcd controller change.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
