### PR TITLE
✨ Add support for configuring NTP servers on bottlerocket through CAPI

### DIFF
--- a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
@@ -98,6 +98,12 @@ password = "{{.RegistryMirrorPassword}}"
 {{- end -}}
 `
 
+	ntpTemplate = `{{ define "ntpSettings" -}}
+[settings.ntp]
+time-servers = [{{stringsJoin .NTPServers ", " }}]
+{{- end -}}
+`
+
 	bottlerocketNodeInitSettingsTemplate = `{{template "hostContainerSlice" .}}
 
 {{template "kubernetesInitSettings" .}}
@@ -128,6 +134,10 @@ password = "{{.RegistryMirrorPassword}}"
 
 {{- if (ne .Taints "")}}
 {{template "taintsTemplate" .}}
+{{- end -}}
+
+{{- if .NTPServers}}
+{{template "ntpSettings" .}}
 {{- end -}}
 `
 )

--- a/bootstrap/kubeadm/internal/bottlerocket/bootstrap_test.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bootstrap_test.go
@@ -40,10 +40,20 @@ no-proxy = []
 [settings.pki.registry-mirror-ca]
 data = "REGISTRYCA"
 trusted=true
+[[settings.container-registry.credentials]]
+registry = "public.ecr.aws"
+username = "admin"
+password = "pass"
+[[settings.container-registry.credentials]]
+registry = "REGISTRYENDPOINT"
+username = "admin"
+password = "pass"
 [settings.kubernetes.node-labels]
 KEY=VAR
 [settings.kubernetes.node-taints]
-KEY=VAR`
+KEY=VAR
+[settings.ntp]
+time-servers = ["1.2.3.4", "time-a.capi.com", "time-b.capi.com"]`
 
 const userDataNoAdminImage = `
 [settings.host-containers.admin]
@@ -99,6 +109,13 @@ func TestGenerateUserData(t *testing.T) {
 				NodeLabels:             "KEY=VAR",
 				Taints:                 "KEY=VAR",
 				ProviderId:             "PROVIDERID",
+				RegistryMirrorUsername: "admin",
+				RegistryMirrorPassword: "pass",
+				NTPServers: []string{
+					"\"1.2.3.4\"",
+					"\"time-a.capi.com\"",
+					"\"time-b.capi.com\"",
+				},
 				HostContainers: []bootstrapv1.BottlerocketHostContainer{
 					{
 						Name:         "admin",

--- a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
@@ -33,6 +33,7 @@ type BottlerocketConfig struct {
 	Taints                                []corev1.Taint
 	BottlerocketCustomHostContainers      []bootstrapv1.BottlerocketHostContainer
 	BottlerocketCustomBootstrapContainers []bootstrapv1.BottlerocketBootstrapContainer
+	NTPServers                            []string
 	RegistryMirrorCredentials
 }
 
@@ -45,6 +46,7 @@ type BottlerocketSettingsInput struct {
 	RegistryMirrorUsername string
 	RegistryMirrorPassword string
 	NodeLabels             string
+	NTPServers             []string
 	Taints                 string
 	ProviderId             string
 	HostContainers         []bootstrapv1.BottlerocketHostContainer
@@ -57,8 +59,8 @@ type HostPath struct {
 }
 
 type RegistryMirrorCredentials struct {
-	Username	string
-	Password	string
+	Username string
+	Password string
 }
 
 func generateBootstrapContainerUserData(kind string, tpl string, data interface{}) ([]byte, error) {
@@ -141,6 +143,9 @@ func generateNodeUserData(kind string, tpl string, data interface{}) ([]byte, er
 	if _, err := tm.Parse(taintsTemplate); err != nil {
 		return nil, errors.Wrapf(err, "failed to parse taints %s template", kind)
 	}
+	if _, err := tm.Parse(ntpTemplate); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse NTP %s template", kind)
+	}
 	t, err := tm.Parse(tpl)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse %s template", kind)
@@ -216,10 +221,14 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
 	if config.RegistryMirrorConfiguration.CACert != "" {
 		bottlerocketInput.RegistryMirrorCACert = base64.StdEncoding.EncodeToString([]byte(config.RegistryMirrorConfiguration.CACert))
 	}
-
 	if config.RegistryMirrorCredentials.Username != "" && config.RegistryMirrorCredentials.Password != "" {
 		bottlerocketInput.RegistryMirrorUsername = config.RegistryMirrorCredentials.Username
 		bottlerocketInput.RegistryMirrorPassword = config.RegistryMirrorCredentials.Password
+	}
+	if len(config.NTPServers) > 0 {
+		for _, ntp := range config.NTPServers {
+			bottlerocketInput.NTPServers = append(bottlerocketInput.NTPServers, strconv.Quote(ntp))
+		}
 	}
 
 	bottlerocketNodeUserData, err := generateNodeUserData("InitBottlerocketNode", bottlerocketNodeInitSettingsTemplate, bottlerocketInput)

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -482,6 +482,9 @@ func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Contex
 		if len(scope.Config.Spec.InitConfiguration.NodeRegistration.Taints) > 0 {
 			bottlerocketConfig.Taints = scope.Config.Spec.InitConfiguration.NodeRegistration.Taints
 		}
+		if scope.Config.Spec.NTP != nil && scope.Config.Spec.NTP.Enabled != nil && *scope.Config.Spec.NTP.Enabled {
+			bottlerocketConfig.NTPServers = scope.Config.Spec.NTP.Servers
+		}
 
 	}
 
@@ -676,6 +679,9 @@ func (r *KubeadmConfigReconciler) joinWorker(ctx context.Context, scope *Scope) 
 		if len(scope.Config.Spec.JoinConfiguration.NodeRegistration.Taints) > 0 {
 			bottlerocketConfig.Taints = scope.Config.Spec.JoinConfiguration.NodeRegistration.Taints
 		}
+		if scope.Config.Spec.NTP != nil && scope.Config.Spec.NTP.Enabled != nil && *scope.Config.Spec.NTP.Enabled {
+			bottlerocketConfig.NTPServers = scope.Config.Spec.NTP.Servers
+		}
 		bootstrapJoinData, err = bottlerocket.NewNode(nodeInput, bottlerocketConfig)
 		if err != nil {
 			scope.Error(err, "Failed to create a worker bottlerocket join configuration")
@@ -811,6 +817,9 @@ func (r *KubeadmConfigReconciler) joinControlplane(ctx context.Context, scope *S
 		if len(scope.Config.Spec.JoinConfiguration.NodeRegistration.Taints) > 0 {
 			bottlerocketConfig.Taints = scope.Config.Spec.JoinConfiguration.NodeRegistration.Taints
 		}
+		if scope.Config.Spec.NTP != nil && scope.Config.Spec.NTP.Enabled != nil && *scope.Config.Spec.NTP.Enabled {
+			bottlerocketConfig.NTPServers = scope.Config.Spec.NTP.Servers
+		}
 		bootstrapJoinData, err = bottlerocket.NewJoinControlPlane(controlPlaneJoinInput, bottlerocketConfig)
 		if err != nil {
 			scope.Error(err, "Failed to generate cloud init for bottlerocket bootstrap control plane")
@@ -930,7 +939,6 @@ func (r *KubeadmConfigReconciler) resolveRegistryCredentials(ctx context.Context
 	}
 	return username, password, nil
 }
-
 
 // ClusterToKubeadmConfigs is a handler.ToRequestsFunc to be used to enqueue
 // requests for reconciliation of KubeadmConfigs.


### PR DESCRIPTION
Signed-off-by: Abhinav <abhinavmpandey08@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Patch CAPI to support setting NTP servers on bottlerocket nodes

