### PR TITLE
Expose clusterctl argument to filter objects per cluster during move

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -142,7 +142,10 @@ func (o *objectMover) FromDirectory(toCluster Client, directory, cluster string)
 
 	// Filter and remove nodes in the graph that do not belong to cluster
 	if cluster != "" {
-		objectGraph.filterCluster(cluster)
+		err = objectGraph.filterCluster(cluster)
+		if err != nil {
+			return errors.Wrap(err, "failed to filter for cluster")
+		}
 	}
 
 	// Restore the objects to the target cluster.

--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -44,13 +44,13 @@ import (
 // ObjectMover defines methods for moving Cluster API objects to another management cluster.
 type ObjectMover interface {
 	// Move moves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target management cluster.
-	Move(namespace string, toCluster Client, dryRun bool) error
+	Move(namespace string, toCluster Client, cluster string, dryRun bool) error
 
 	// ToDirectory writes all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target directory.
-	ToDirectory(namespace string, directory string) error
+	ToDirectory(namespace string, directory, cluster string) error
 
 	// FromDirectory reads all the Cluster API objects existing in a configured directory to a target management cluster.
-	FromDirectory(toCluster Client, directory string) error
+	FromDirectory(toCluster Client, directory, cluster string) error
 }
 
 // objectMover implements the ObjectMover interface.
@@ -63,7 +63,7 @@ type objectMover struct {
 // ensure objectMover implements the ObjectMover interface.
 var _ ObjectMover = &objectMover{}
 
-func (o *objectMover) Move(namespace string, toCluster Client, dryRun bool) error {
+func (o *objectMover) Move(namespace string, toCluster Client, cluster string, dryRun bool) error {
 	log := logf.Log
 	log.Info("Performing move...")
 	o.dryRun = dryRun
@@ -80,7 +80,7 @@ func (o *objectMover) Move(namespace string, toCluster Client, dryRun bool) erro
 		}
 	}
 
-	objectGraph, err := o.getObjectGraph(namespace)
+	objectGraph, err := o.getObjectGraph(namespace, cluster)
 	if err != nil {
 		return errors.Wrap(err, "failed to get object graph")
 	}
@@ -94,11 +94,11 @@ func (o *objectMover) Move(namespace string, toCluster Client, dryRun bool) erro
 	return o.move(objectGraph, proxy)
 }
 
-func (o *objectMover) ToDirectory(namespace string, directory string) error {
+func (o *objectMover) ToDirectory(namespace, directory, cluster string) error {
 	log := logf.Log
 	log.Info("Moving to directory...")
 
-	objectGraph, err := o.getObjectGraph(namespace)
+	objectGraph, err := o.getObjectGraph(namespace, cluster)
 	if err != nil {
 		return errors.Wrap(err, "failed to get object graph")
 	}
@@ -106,7 +106,7 @@ func (o *objectMover) ToDirectory(namespace string, directory string) error {
 	return o.toDirectory(objectGraph, directory)
 }
 
-func (o *objectMover) FromDirectory(toCluster Client, directory string) error {
+func (o *objectMover) FromDirectory(toCluster Client, directory, cluster string) error {
 	log := logf.Log
 	log.Info("Moving from directory...")
 
@@ -139,6 +139,11 @@ func (o *objectMover) FromDirectory(toCluster Client, directory string) error {
 
 	// Check whether nodes are not included in GVK considered for fromDirectory.
 	objectGraph.checkVirtualNode()
+
+	// Filter and remove nodes in the graph that do not belong to cluster
+	if cluster != "" {
+		objectGraph.filterCluster(cluster)
+	}
 
 	// Restore the objects to the target cluster.
 	proxy := toCluster.Proxy()
@@ -177,7 +182,7 @@ func (o *objectMover) filesToObjs(dir string) ([]unstructured.Unstructured, erro
 	return objs, nil
 }
 
-func (o *objectMover) getObjectGraph(namespace string) (*objectGraph, error) {
+func (o *objectMover) getObjectGraph(namespace, cluster string) (*objectGraph, error) {
 	objectGraph := newObjectGraph(o.fromProxy, o.fromProviderInventory)
 
 	// Gets all the types defined by the CRDs installed by clusterctl plus the ConfigMap/Secret core types.
@@ -189,7 +194,8 @@ func (o *objectMover) getObjectGraph(namespace string) (*objectGraph, error) {
 	// Discovery the object graph for the selected types:
 	// - Nodes are defined the Kubernetes objects (Clusters, Machines etc.) identified during the discovery process.
 	// - Edges are derived by the OwnerReferences between nodes.
-	if err := objectGraph.Discovery(namespace); err != nil {
+	// - Filters and remove nodes that do not belong to provided cluster name
+	if err := objectGraph.Discovery(namespace, cluster); err != nil {
 		return nil, errors.Wrap(err, "failed to discover the object graph")
 	}
 

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -658,7 +658,7 @@ func Test_objectMover_backupTargetObject(t *testing.T) {
 			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
-			g.Expect(graph.Discovery("")).To(Succeed())
+			g.Expect(graph.Discovery("", "")).To(Succeed())
 
 			// Run backupTargetObject on nodes in graph
 			mover := objectMover{
@@ -747,7 +747,7 @@ func Test_objectMover_restoreTargetObject(t *testing.T) {
 			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
-			g.Expect(graph.Discovery("")).To(Succeed())
+			g.Expect(graph.Discovery("", "")).To(Succeed())
 
 			// gets a fakeProxy to an empty cluster with all the required CRDs
 			toProxy := getFakeProxyWithCRDs()
@@ -853,7 +853,7 @@ func Test_objectMover_toDirectory(t *testing.T) {
 			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
-			g.Expect(graph.Discovery("")).To(Succeed())
+			g.Expect(graph.Discovery("", "")).To(Succeed())
 
 			// Run toDirectory
 			mover := objectMover{
@@ -1070,7 +1070,7 @@ func Test_getMoveSequence(t *testing.T) {
 			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
-			g.Expect(graph.Discovery("")).To(Succeed())
+			g.Expect(graph.Discovery("", "")).To(Succeed())
 
 			moveSequence := getMoveSequence(graph)
 			g.Expect(moveSequence.groups).To(HaveLen(len(tt.wantMoveGroups)))
@@ -1101,7 +1101,7 @@ func Test_objectMover_move_dryRun(t *testing.T) {
 			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
-			g.Expect(graph.Discovery("")).To(Succeed())
+			g.Expect(graph.Discovery("", "")).To(Succeed())
 
 			// gets a fakeProxy to an empty cluster with all the required CRDs
 			toProxy := getFakeProxyWithCRDs()
@@ -1174,7 +1174,7 @@ func Test_objectMover_move(t *testing.T) {
 			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
-			g.Expect(graph.Discovery("")).To(Succeed())
+			g.Expect(graph.Discovery("", "")).To(Succeed())
 
 			// gets a fakeProxy to an empty cluster with all the required CRDs
 			toProxy := getFakeProxyWithCRDs()
@@ -1445,7 +1445,7 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
-			g.Expect(graph.Discovery("")).To(Succeed())
+			g.Expect(graph.Discovery("", "")).To(Succeed())
 
 			o := &objectMover{
 				fromProxy: graph.proxy,
@@ -1685,7 +1685,7 @@ func Test_objectMoverService_ensureNamespaces(t *testing.T) {
 			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// Trigger discovery the content of the source cluster
-			g.Expect(graph.Discovery("")).To(Succeed())
+			g.Expect(graph.Discovery("", "")).To(Succeed())
 
 			mover := objectMover{
 				fromProxy: graph.proxy,

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -38,6 +38,10 @@ type MoveOptions struct {
 	// namespace will be used.
 	Namespace string
 
+	// Cluster defines the name of the workload cluster and its dependent objects to be moved. If unspecified,
+	// all the clusters will be moved.
+	Cluster string
+
 	// FromDirectory apply configuration from directory.
 	FromDirectory string
 
@@ -94,7 +98,7 @@ func (c *clusterctlClient) move(options MoveOptions) error {
 		}
 	}
 
-	return fromCluster.ObjectMover().Move(options.Namespace, toCluster, options.DryRun)
+	return fromCluster.ObjectMover().Move(options.Namespace, toCluster, options.Cluster, options.DryRun)
 }
 
 func (c *clusterctlClient) fromDirectory(options MoveOptions) error {
@@ -107,7 +111,7 @@ func (c *clusterctlClient) fromDirectory(options MoveOptions) error {
 		return err
 	}
 
-	return toCluster.ObjectMover().FromDirectory(toCluster, options.FromDirectory)
+	return toCluster.ObjectMover().FromDirectory(toCluster, options.FromDirectory, options.Cluster)
 }
 
 func (c *clusterctlClient) toDirectory(options MoveOptions) error {
@@ -129,7 +133,7 @@ func (c *clusterctlClient) toDirectory(options MoveOptions) error {
 		return err
 	}
 
-	return fromCluster.ObjectMover().ToDirectory(options.Namespace, options.ToDirectory)
+	return fromCluster.ObjectMover().ToDirectory(options.Namespace, options.ToDirectory, options.Cluster)
 }
 
 func (c *clusterctlClient) getClusterClient(kubeconfig Kubeconfig) (cluster.Client, error) {

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -38,9 +38,9 @@ type MoveOptions struct {
 	// namespace will be used.
 	Namespace string
 
-	// Cluster defines the name of the workload cluster and its dependent objects to be moved. If unspecified,
+	// ClusterName defines the name of the workload cluster and its dependent objects to be moved. If unspecified,
 	// all the clusters will be moved.
-	Cluster string
+	ClusterName string
 
 	// FromDirectory apply configuration from directory.
 	FromDirectory string
@@ -98,7 +98,7 @@ func (c *clusterctlClient) move(options MoveOptions) error {
 		}
 	}
 
-	return fromCluster.ObjectMover().Move(options.Namespace, toCluster, options.Cluster, options.DryRun)
+	return fromCluster.ObjectMover().Move(options.Namespace, toCluster, options.ClusterName, options.DryRun)
 }
 
 func (c *clusterctlClient) fromDirectory(options MoveOptions) error {
@@ -111,7 +111,7 @@ func (c *clusterctlClient) fromDirectory(options MoveOptions) error {
 		return err
 	}
 
-	return toCluster.ObjectMover().FromDirectory(toCluster, options.FromDirectory, options.Cluster)
+	return toCluster.ObjectMover().FromDirectory(toCluster, options.FromDirectory, options.ClusterName)
 }
 
 func (c *clusterctlClient) toDirectory(options MoveOptions) error {
@@ -133,7 +133,7 @@ func (c *clusterctlClient) toDirectory(options MoveOptions) error {
 		return err
 	}
 
-	return fromCluster.ObjectMover().ToDirectory(options.Namespace, options.ToDirectory, options.Cluster)
+	return fromCluster.ObjectMover().ToDirectory(options.Namespace, options.ToDirectory, options.ClusterName)
 }
 
 func (c *clusterctlClient) getClusterClient(kubeconfig Kubeconfig) (cluster.Client, error) {

--- a/cmd/clusterctl/cmd/move.go
+++ b/cmd/clusterctl/cmd/move.go
@@ -108,7 +108,7 @@ func runMove() error {
 		FromDirectory:  mo.fromDirectory,
 		ToDirectory:    mo.toDirectory,
 		Namespace:      mo.namespace,
-		Cluster:        mo.filterCluster,
+		ClusterName:    mo.filterCluster,
 		DryRun:         mo.dryRun,
 	})
 }

--- a/cmd/clusterctl/cmd/move.go
+++ b/cmd/clusterctl/cmd/move.go
@@ -29,6 +29,7 @@ type moveOptions struct {
 	toKubeconfig          string
 	toKubeconfigContext   string
 	namespace             string
+	filterCluster         string
 	fromDirectory         string
 	toDirectory           string
 	dryRun                bool
@@ -78,6 +79,8 @@ func init() {
 		"Write Cluster API objects and all dependencies from a management cluster to directory.")
 	moveCmd.Flags().StringVar(&mo.fromDirectory, "from-directory", "",
 		"Read Cluster API objects and all dependencies from a directory into a management cluster.")
+	moveCmd.Flags().StringVar(&mo.filterCluster, "filter-cluster", "",
+		"Name of the cluster to be moved. All the dependent objects will also be moved. If empty, all clusters will be moved")
 
 	moveCmd.MarkFlagsMutuallyExclusive("to-directory", "to-kubeconfig")
 	moveCmd.MarkFlagsMutuallyExclusive("from-directory", "to-directory")
@@ -105,6 +108,7 @@ func runMove() error {
 		FromDirectory:  mo.fromDirectory,
 		ToDirectory:    mo.toDirectory,
 		Namespace:      mo.namespace,
+		Cluster:        mo.filterCluster,
 		DryRun:         mo.dryRun,
 	})
 }


### PR DESCRIPTION
Clusterctl move was designed as a one time command to be run when creating management clusters, to move the CAPI objects from kind (bootstrap cluster) to the provider/workload cluster. Move command takes in a `namespace` option to filter for objects only present in the namespace. 

This changes adds an option `--filter-cluster` to filter objects that belong or are dependents of the provided cluster. This includes machines, secrets, etc. Filter cluster options works for all move scenarios
- From and To a cluster
- To Directory
- From Directory