### PR TITLE
Move objects with force move label and no cluster tenants

### DIFF
--- a/cmd/clusterctl/client/cluster/objectgraph.go
+++ b/cmd/clusterctl/client/cluster/objectgraph.go
@@ -503,6 +503,14 @@ func (o *objectGraph) filterCluster(clusterName string) error {
 				object.identity.Name, strings.Join(clusterTenants, ","))
 		}
 
+		// CAPI has a force move label that can be used on CRD to identify objects to be moved CRDs with that label has
+		// `forceMove` set to true. Only move forceMove nodes if and only if they do not have a cluster Tenant.
+		// If an object has `forceMove` and also has a clusterTenant, the object has clear owner ref assigned and can be
+		// dropped if the cluster being filtered is not part of its tenants
+		if len(clusterTenants) == 0 && object.forceMove {
+			continue
+		}
+
 		if !hasFilterCluster {
 			if _, ok := o.uidToNode[object.identity.UID]; ok {
 				delete(o.uidToNode, object.identity.UID)

--- a/cmd/clusterctl/client/cluster/objectgraph_test.go
+++ b/cmd/clusterctl/client/cluster/objectgraph_test.go
@@ -1988,6 +1988,49 @@ func TestObjectGraph_DiscoveryByCluster(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "two clusters with external force object, read only 1 cluster & both external objects",
+			args: args{
+				cluster: "cluster1", // read only from ns1
+				objs: func() []client.Object {
+					objs := []client.Object{}
+					objs = append(objs, test.NewFakeCluster("ns1", "cluster1").Objs()...)
+					objs = append(objs, test.NewFakeExternalObject("ns1", "externalObject1").Objs()...)
+					objs = append(objs, test.NewFakeCluster("ns1", "cluster2").Objs()...)
+					objs = append(objs, test.NewFakeExternalObject("ns2", "externalObject2").Objs()...)
+					return objs
+				}(),
+			},
+			want: wantGraph{
+				nodes: map[string]wantGraphItem{
+					"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1": {
+						forceMove:          true,
+						forceMoveHierarchy: true,
+					},
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureCluster, ns1/cluster1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1",
+						},
+					},
+					"/v1, Kind=Secret, ns1/cluster1-ca": {
+						softOwners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1", // NB. this secret is not linked to the cluster through owner ref
+						},
+					},
+					"/v1, Kind=Secret, ns1/cluster1-kubeconfig": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1",
+						},
+					},
+					"external.cluster.x-k8s.io/v1beta1, Kind=GenericExternalObject, ns1/externalObject1": {
+						forceMove: true,
+					},
+					"external.cluster.x-k8s.io/v1beta1, Kind=GenericExternalObject, ns2/externalObject2": {
+						forceMove: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
CAPI has a force move label that helps clusterctl identify if extra objects should be moved. This change will make --filter-cluster also pick up objects that have the force move label only if they are not a direct dependent of any cluster. 
Objects that have force move and depend on cluster being filtered will be moved, Objects having force move and depend on cluster not being filtered for will be dropped from the tree and will not be moved.