### PR TITLE
✨ Add support for in-place upgrade in KCP

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go
@@ -35,6 +35,9 @@ const (
 	// RollingUpdateStrategyType replaces the old control planes by new one using rolling update
 	// i.e. gradually scale up or down the old control planes and scale up or down the new one.
 	RollingUpdateStrategyType RolloutStrategyType = "RollingUpdate"
+
+	// InPlaceUpgradeStrategyType updates the node in place by delegating the upgrade to an external entity.
+	InPlaceUpgradeStrategyType RolloutStrategyType = "InPlace"
 )
 
 const (
@@ -64,6 +67,11 @@ const (
 	// NOTE: if something external to CAPI removes this annotation the system this can lead to
 	// failures in updating remediation retry (the counter restarts from zero).
 	RemediationForAnnotation = "controlplane.cluster.x-k8s.io/remediation-for"
+
+	// InPlaceUpgradeAnnotation is used to denote that the KCP object needs to be in-place upgraded by an external entity.
+	// This annotation will be added to the KCP object when `rolloutStrategy.type` is set to `InPlace`.
+	// The external upgrader entity should watch for the annotation and trigger an upgrade when it's added.
+	InPlaceUpgradeAnnotation = "controlplane.clusters.x-k8s.io/in-place-upgrade-needed"
 
 	// DefaultMinHealthyPeriod defines the default minimum period before we consider a remediation on a
 	// machine unrelated from the previous remediation.

--- a/controlplane/kubeadm/internal/controllers/upgrade.go
+++ b/controlplane/kubeadm/internal/controllers/upgrade.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
@@ -26,6 +27,7 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/version"
 )
@@ -37,7 +39,7 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 ) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
-	if controlPlane.KCP.Spec.RolloutStrategy == nil || controlPlane.KCP.Spec.RolloutStrategy.RollingUpdate == nil {
+	if controlPlane.KCP.Spec.RolloutStrategy == nil {
 		return ctrl.Result{}, errors.New("rolloutStrategy is not set")
 	}
 
@@ -138,8 +140,12 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 			return r.scaleUpControlPlane(ctx, controlPlane)
 		}
 		return r.scaleDownControlPlane(ctx, controlPlane, machinesRequireUpgrade)
+	case controlplanev1.InPlaceUpgradeStrategyType:
+		annotations.AddAnnotations(controlPlane.KCP, map[string]string{controlplanev1.InPlaceUpgradeAnnotation: "true"})
+		logger.Info("RolloutStrategy type set to InPlaceUpgradeStrategyType, adding the annotation and requeuing", "annotation", controlplanev1.InPlaceUpgradeAnnotation)
+		return ctrl.Result{RequeueAfter: time.Second * 30}, nil
 	default:
-		logger.Info("RolloutStrategy type is not set to RollingUpdateStrategyType, unable to determine the strategy for rolling out machines")
+		logger.Info("RolloutStrategy type is not set to RollingUpdateStrategyType or InPlaceUpgradeStrategyType, unable to determine the strategy for rolling out machines")
 		return ctrl.Result{}, nil
 	}
 }

--- a/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
@@ -407,7 +407,7 @@ func validateRolloutBefore(rolloutBefore *controlplanev1.RolloutBefore, pathPref
 func validateRolloutStrategy(rolloutStrategy *controlplanev1.RolloutStrategy, replicas *int32, pathPrefix *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if rolloutStrategy == nil {
+	if rolloutStrategy == nil || rolloutStrategy.Type == controlplanev1.InPlaceUpgradeStrategyType {
 		return allErrs
 	}
 
@@ -416,7 +416,7 @@ func validateRolloutStrategy(rolloutStrategy *controlplanev1.RolloutStrategy, re
 			allErrs,
 			field.Required(
 				pathPrefix.Child("type"),
-				"only RollingUpdateStrategyType is supported",
+				"only RollingUpdateStrategyType and InPlaceUpgradeStrategyType are supported",
 			),
 		)
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds support for `InPlace` upgrade strategy in KCP. When the deployment strategy is set to `InPlace`, the `kubeadm-control-plane-controller` adds a `controlplane.clusters.x-k8s.io/in-place-upgrade-needed` annotation to the KCP object when an upgrade is needed. The external upgrader should watch for this annotation and trigger an in-place upgrade when it's added. 
After the upgrade is done, the external upgrader is expected to update the statuses and remove this annotation.
